### PR TITLE
멀티 모니터 전체 캡처 지원

### DIFF
--- a/rust/src/capture.rs
+++ b/rust/src/capture.rs
@@ -5,13 +5,41 @@ use rusttype::{point, Font, Scale};
 use std::fs;
 use std::path::Path;
 
+use windows_sys::Win32::Foundation::{BOOL, LPARAM, RECT};
 use windows_sys::Win32::Graphics::Gdi::{
-    BitBlt, CreateCompatibleDC, CreateDCW, CreateDIBSection, DeleteDC, DeleteObject, GetDIBits,
-    SelectObject, BITMAPINFO, BITMAPINFOHEADER, BI_RGB, CAPTUREBLT, DIB_RGB_COLORS, SRCCOPY,
+    BitBlt, CreateCompatibleDC, CreateDCW, CreateDIBSection, DeleteDC, DeleteObject,
+    EnumDisplayMonitors, GetDIBits, SelectObject, BITMAPINFO, BITMAPINFOHEADER, BI_RGB,
+    CAPTUREBLT, DIB_RGB_COLORS, HDC, HMONITOR, SRCCOPY,
 };
 use windows_sys::Win32::UI::WindowsAndMessaging::{
     GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
 };
+
+/// EnumDisplayMonitors 콜백 - 모니터 영역을 수집한다
+unsafe extern "system" fn monitor_enum_proc(
+    _monitor: HMONITOR,
+    _dc: HDC,
+    rect: *mut RECT,
+    lparam: LPARAM,
+) -> BOOL {
+    let rects = &mut *(lparam as *mut Vec<RECT>);
+    rects.push(*rect);
+    1
+}
+
+/// 연결된 모든 모니터의 영역 목록
+pub fn monitor_rects() -> Vec<RECT> {
+    let mut rects: Vec<RECT> = Vec::new();
+    unsafe {
+        EnumDisplayMonitors(
+            0,
+            std::ptr::null(),
+            Some(monitor_enum_proc),
+            &mut rects as *mut Vec<RECT> as LPARAM,
+        );
+    }
+    rects
+}
 
 /// 전체 가상 화면을 RGB 이미지로 캡처한다.
 pub fn grab_screen() -> Result<RgbImage, String> {
@@ -52,7 +80,33 @@ pub fn grab_screen() -> Result<RgbImage, String> {
         }
 
         let old = SelectObject(mem_dc, bitmap);
-        let ok = BitBlt(mem_dc, 0, 0, w, h, screen_dc, x, y, SRCCOPY | CAPTUREBLT);
+        // 모니터별로 각각 캡처해 가상 화면 좌표 기준으로 합성한다 (멀티 모니터 전체 캡처).
+        let monitors = monitor_rects();
+        let ok = if monitors.is_empty() {
+            // 모니터 열거 실패 시 가상 화면 전체를 한 번에 캡처
+            BitBlt(mem_dc, 0, 0, w, h, screen_dc, x, y, SRCCOPY | CAPTUREBLT)
+        } else {
+            let mut all_ok = 1;
+            for rc in &monitors {
+                let mw = rc.right - rc.left;
+                let mh = rc.bottom - rc.top;
+                if BitBlt(
+                    mem_dc,
+                    rc.left - x,
+                    rc.top - y,
+                    mw,
+                    mh,
+                    screen_dc,
+                    rc.left,
+                    rc.top,
+                    SRCCOPY | CAPTUREBLT,
+                ) == 0
+                {
+                    all_ok = 0;
+                }
+            }
+            all_ok
+        };
         SelectObject(mem_dc, old);
 
         let result = if ok == 0 {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -129,10 +129,20 @@ fn capture_worker(shared: Arc<Shared>, ctx: egui::Context) {
     if font.is_none() {
         logger::warn("시스템 폰트를 찾을 수 없어 타임스탬프 오버레이를 생략합니다");
     }
+    let mut logged_area = false;
     while shared.capturing.load(Ordering::Relaxed) {
         let settings = shared.settings.lock().unwrap().clone();
         match capture::grab_screen() {
             Ok(mut img) => {
+                if !logged_area {
+                    logged_area = true;
+                    logger::info(&format!(
+                        "캡처 영역: {}x{} (모니터 {}개)",
+                        img.width(),
+                        img.height(),
+                        capture::monitor_rects().len()
+                    ));
+                }
                 capture::add_timestamp_overlay(&mut img, font.as_ref());
                 let ts = chrono::Local::now().format("%Y%m%d_%H%M%S_%3f").to_string();
                 let ext = if settings.webp { "webp" } else { "jpg" };


### PR DESCRIPTION
## 변경 내용

- `EnumDisplayMonitors`로 연결된 모든 모니터 영역을 열거하고, 각 모니터를 개별 BitBlt해서 가상 화면 좌표 기준의 한 이미지로 합성
- 모니터 배치(좌우/상하)와 해상도 차이에 관계없이 전체 화면이 담기며, 빈 영역은 검정으로 채움
- 모니터 열거 실패 시 기존 방식(가상 화면 전체 단일 BitBlt)으로 폴백
- 첫 캡처 시 `캡처 영역: WxH (모니터 N개)` 로그 기록

단일 모니터(3440x1440) 환경에서 정상 캡처 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)