### PR TITLE
settings.json 설정 저장/복원 구현

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1266,11 +1266,19 @@ dependencies = [
  "raw-window-handle 0.6.2",
  "rfd",
  "rusttype",
+ "serde",
+ "serde_json",
  "tray-icon",
  "webp",
  "windows-sys 0.52.0",
  "winres",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -2138,6 +2146,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3390,3 +3411,9 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,8 @@ image = { version = "0.24", default-features = false, features = ["jpeg", "png"]
 webp = { version = "0.3", default-features = false }
 rusttype = "0.9"
 chrono = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tray-icon = "0.14"
 rfd = { version = "0.14", default-features = false }
 raw-window-handle = "0.6"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -4,6 +4,7 @@
 mod capture;
 mod cleanup;
 mod logger;
+mod settings;
 
 use cleanup::RollingCleanup;
 use eframe::egui;
@@ -243,6 +244,7 @@ struct App {
     cleanup_warning: String,
     cleanup_timer_start: Option<Instant>,
     quality: u8,
+    saved_settings: settings::AppSettings,
     started_at: Instant,
     hidden_after_start: bool,
     window_visible: bool,
@@ -252,7 +254,11 @@ impl App {
     fn new(cc: &eframe::CreationContext) -> Self {
         setup_korean_fonts(&cc.egui_ctx);
 
-        let save_folder = PathBuf::from("screenshots");
+        let loaded = settings::load();
+        if !std::path::Path::new(settings::SETTINGS_FILE).exists() {
+            settings::save(&loaded);
+        }
+        let save_folder = PathBuf::from(&loaded.save_folder);
         let _ = std::fs::create_dir_all(&save_folder);
 
         let shared = Arc::new(Shared {
@@ -260,20 +266,20 @@ impl App {
             capture_count: AtomicU64::new(0),
             status: Mutex::new("대기 중...".into()),
             settings: Mutex::new(CaptureSettings {
-                interval_secs: 2.0,
+                interval_secs: loaded.capture_interval_secs,
                 save_folder: save_folder.clone(),
-                webp: false,
-                quality: 15,
-                resolution: "원본".into(),
-                grayscale: false,
+                webp: loaded.image_format == "WEBP",
+                quality: loaded.image_quality,
+                resolution: loaded.image_resolution.clone(),
+                grayscale: loaded.image_grayscale,
             }),
-            cleanup_enabled: AtomicBool::new(true),
+            cleanup_enabled: AtomicBool::new(loaded.cleanup_enabled),
             quit: AtomicBool::new(false),
         });
         logger::info("프로그램 시작됨");
         logger::info(&format!("프로그램 PID: {}", std::process::id()));
 
-        let rolling_cleanup = RollingCleanup::new(save_folder, 24 * 3600);
+        let rolling_cleanup = RollingCleanup::new(save_folder, loaded.cleanup_age_secs());
 
         // 트레이 아이콘 설정 및 메뉴 이벤트 전달 채널
         let tray = match build_tray() {
@@ -335,15 +341,16 @@ impl App {
             shared,
             rolling_cleanup,
             tray,
-            interval_text: "2.0".into(),
+            interval_text: format!("{}", loaded.capture_interval_secs),
             interval_info: "범위: 0.1 ~ 3600초 (1시간)".into(),
             interval_info_error: false,
-            cleanup_enabled: true,
-            cleanup_age_text: "24".into(),
-            cleanup_unit_hours: true,
+            cleanup_enabled: loaded.cleanup_enabled,
+            cleanup_age_text: format!("{}", loaded.cleanup_age_value),
+            cleanup_unit_hours: loaded.cleanup_age_unit != "분",
             cleanup_warning: String::new(),
             cleanup_timer_start: None,
-            quality: 15,
+            quality: loaded.image_quality,
+            saved_settings: loaded,
             started_at: Instant::now(),
             hidden_after_start: false,
             window_visible: true,
@@ -432,6 +439,33 @@ impl App {
 
     fn stop_capture(&mut self) {
         stop_capture_shared(&self.shared, &self.rolling_cleanup);
+    }
+
+    /// 현재 상태를 AppSettings로 스냅샷 (텍스트 입력이 유효하지 않으면 마지막 저장값 유지)
+    fn current_settings(&self) -> settings::AppSettings {
+        let s = self.shared.settings.lock().unwrap();
+        let cleanup_age_value = self
+            .cleanup_age_text
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .filter(|v| *v > 0.0)
+            .unwrap_or(self.saved_settings.cleanup_age_value);
+        settings::AppSettings {
+            capture_interval_secs: s.interval_secs,
+            save_folder: s.save_folder.display().to_string(),
+            image_format: if s.webp { "WEBP".into() } else { "JPEG".into() },
+            image_quality: s.quality,
+            image_resolution: s.resolution.clone(),
+            image_grayscale: s.grayscale,
+            cleanup_enabled: self.cleanup_enabled,
+            cleanup_age_value,
+            cleanup_age_unit: if self.cleanup_unit_hours {
+                "시간".into()
+            } else {
+                "분".into()
+            },
+        }
     }
 
     fn quit(&mut self, ctx: &egui::Context) {
@@ -738,6 +772,13 @@ impl eframe::App for App {
                 });
             });
         });
+
+        // 설정이 바뀌었으면 settings.json에 즉시 저장
+        let current = self.current_settings();
+        if current != self.saved_settings {
+            settings::save(&current);
+            self.saved_settings = current;
+        }
     }
 }
 

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -1,0 +1,100 @@
+//! settings.json 저장/복원
+
+use serde::{Deserialize, Serialize};
+
+pub const SETTINGS_FILE: &str = "settings.json";
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[serde(default)]
+pub struct AppSettings {
+    pub capture_interval_secs: f64,
+    pub save_folder: String,
+    pub image_format: String, // "JPEG" | "WEBP"
+    pub image_quality: u8,
+    pub image_resolution: String,
+    pub image_grayscale: bool,
+    pub cleanup_enabled: bool,
+    pub cleanup_age_value: f64,
+    pub cleanup_age_unit: String, // "분" | "시간"
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            capture_interval_secs: 2.0,
+            save_folder: "screenshots".into(),
+            image_format: "JPEG".into(),
+            image_quality: 15,
+            image_resolution: "원본".into(),
+            image_grayscale: false,
+            cleanup_enabled: true,
+            cleanup_age_value: 24.0,
+            cleanup_age_unit: "시간".into(),
+        }
+    }
+}
+
+impl AppSettings {
+    /// 범위를 벗어난 값을 기본 범위로 보정
+    pub fn sanitized(mut self) -> Self {
+        if !(0.1..=3600.0).contains(&self.capture_interval_secs) {
+            self.capture_interval_secs = 2.0;
+        }
+        self.image_quality = self.image_quality.clamp(1, 100);
+        if self.image_format != "WEBP" {
+            self.image_format = "JPEG".into();
+        }
+        const RESOLUTIONS: [&str; 5] = ["원본", "1920x1080", "1280x720", "1024x768", "800x600"];
+        if !RESOLUTIONS.contains(&self.image_resolution.as_str()) {
+            self.image_resolution = "원본".into();
+        }
+        if self.cleanup_age_unit != "분" {
+            self.cleanup_age_unit = "시간".into();
+        }
+        let valid_age = if self.cleanup_age_unit == "분" {
+            (1.0..=60.0).contains(&self.cleanup_age_value)
+        } else {
+            (1.0..=525600.0).contains(&self.cleanup_age_value)
+        };
+        if !valid_age {
+            self.cleanup_age_value = 24.0;
+            self.cleanup_age_unit = "시간".into();
+        }
+        if self.save_folder.trim().is_empty() {
+            self.save_folder = "screenshots".into();
+        }
+        self
+    }
+
+    pub fn cleanup_age_secs(&self) -> u64 {
+        if self.cleanup_age_unit == "분" {
+            (self.cleanup_age_value * 60.0) as u64
+        } else {
+            (self.cleanup_age_value * 3600.0) as u64
+        }
+    }
+}
+
+pub fn load() -> AppSettings {
+    match std::fs::read_to_string(SETTINGS_FILE) {
+        Ok(text) => match serde_json::from_str::<AppSettings>(&text) {
+            Ok(s) => s.sanitized(),
+            Err(e) => {
+                crate::logger::warn(&format!("settings.json 파싱 실패, 기본값 사용: {}", e));
+                AppSettings::default()
+            }
+        },
+        Err(_) => AppSettings::default(),
+    }
+}
+
+pub fn save(settings: &AppSettings) {
+    match serde_json::to_string_pretty(settings) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(SETTINGS_FILE, json) {
+                crate::logger::warn(&format!("settings.json 저장 실패: {}", e));
+            }
+        }
+        Err(e) => crate::logger::warn(&format!("settings.json 직렬화 실패: {}", e)),
+    }
+}


### PR DESCRIPTION
## 변경 내용

- 모든 설정(캡처 간격, 저장 경로, 이미지 포맷/품질/해상도/흑백, 자동 삭제 활성화/주기/단위)을 `settings.json`에 저장하고 시작 시 복원
- 설정이 바뀌면 즉시 저장, 파일이 없으면 기본값으로 생성
- 파싱 실패나 범위를 벗어난 값은 기본값으로 보정 후 적용
- `serde`/`serde_json` 의존성 추가 (Rust 1.77.2 호환 확인)

검증: 기본값 생성 → 파일 수정(5초 간격, WebP, 품질 30) → 재시작 시 적용(WebP 파일이 5초 간격으로 생성) 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)