### PR TITLE
32비트 빌드 지원, 앱 이름 변경(화면 캡쳐), 시작 시 트레이 상주

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # capturemoni
 
-일정 간격으로 전체 화면을 캡처해 저장하는 화면 모니터링 프로그램. 시스템 트레이에 상주하며, 오래된 캡처 파일을 자동 삭제한다.
+일정 간격으로 전체 화면(멀티 모니터 포함)을 캡처해 저장하는 **화면 캡쳐** 프로그램. 시작 시 창을 띄우지 않고 시스템 트레이에만 상주하며, 오래된 캡처 파일을 자동 삭제한다.
 
 두 가지 구현이 있다.
 
 ## rust/ — Rust 버전 (권장, Windows 7 호환)
 
-- GUI: eframe(egui), 캡처: GDI(BitBlt), 트레이: tray-icon
-- 기능: 캡처 간격(0.1~3600초), 저장 경로 변경, JPEG/WebP 품질·해상도·흑백 설정, 타임스탬프 오버레이, 10분 주기 자동 삭제, 날짜별 로그(`logs/년/월/일.log`), 트레이 메뉴(표시/시작/정지/종료)
-- 빌드: Rust 1.77.2 + `x86_64-pc-windows-msvc` (Windows 7 호환을 위한 고정 버전)
+- GUI: eframe(egui), 캡처: GDI(BitBlt, 모든 모니터 합성), 트레이: tray-icon
+- 기능: 캡처 간격(0.1~3600초), 저장 경로 변경, JPEG/WebP 품질·해상도·흑백 설정, 타임스탬프 오버레이, 10분 주기 자동 삭제, 날짜별 로그(`logs/년/월/일.log`), 트레이 메뉴(표시/시작/정지/종료), `settings.json` 설정 저장·복원
+- 시작 시 창이 뜨지 않고 트레이 상주. 트레이 "화면 캡쳐 표시"로 창을 연다.
+- 빌드: Rust 1.77.2 + `x86_64-pc-windows-msvc`(64비트) / `i686-pc-windows-msvc`(32비트). Windows 7/10/11 호환.
 
 ```powershell
 cd rust
 cargo +1.77.2 build --release --locked --target x86_64-pc-windows-msvc
+cargo +1.77.2 build --release --locked --target i686-pc-windows-msvc
 ```
 
 자세한 릴리스 빌드·배포 절차는 [docs/release-build.md](docs/release-build.md) 참고.

--- a/docs/release-build.md
+++ b/docs/release-build.md
@@ -1,6 +1,6 @@
 # 릴리스 빌드 절차
 
-이 문서는 capturemoni(intervalcapture) 클라이언트 배포 빌드 절차이다.
+이 문서는 capturemoni(intervalcapture) 클라이언트 배포 빌드 절차이다. 클라이언트는 64비트와 32비트 두 가지로 빌드하며, 둘 다 Windows 7 / 10 / 11에서 실행되어야 한다.
 
 ## 공통 준비
 
@@ -9,89 +9,124 @@ Rust는 Windows 7 클라이언트 호환성을 위해 1.77.2를 사용한다. `r
 ```powershell
 rustup toolchain install 1.77.2
 rustup +1.77.2 target add x86_64-pc-windows-msvc
+rustup +1.77.2 target add i686-pc-windows-msvc
 ```
 
-`rust/.cargo/config.toml`에는 MSVC CRT 정적 링크 옵션을 둔다.
+`rust/.cargo/config.toml`에는 두 타깃 모두 MSVC CRT 정적 링크 옵션을 둔다.
 
 ```toml
 [target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.i686-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 ```
 
 의존성 잠금: `Cargo.lock`은 Rust 1.77.2 호환을 위해 일부 크레이트(cc, jobserver, idna_adapter, unicode-segmentation 등)를 구버전으로 고정했다. 빌드는 반드시 `--locked`로 수행하고, 새 의존성을 추가할 때는 최신 stable cargo(MSRV 인식 리졸버)로 lockfile을 갱신한 뒤 1.77.2로 빌드가 되는지 확인한다.
 
-## 클라이언트 빌드
-
-클라이언트는 Windows 7, Windows 10, Windows 11에서 실행되어야 하므로 Rust 1.77.2와 `x86_64-pc-windows-msvc` 타깃으로 빌드한다.
+## 클라이언트 빌드 (64비트 / 32비트)
 
 ```powershell
 cd rust
 cargo +1.77.2 build --release --locked --target x86_64-pc-windows-msvc
+cargo +1.77.2 build --release --locked --target i686-pc-windows-msvc
 ```
 
-빌드 결과를 배포 폴더에 복사한다.
+산출물:
 
-```powershell
-Copy-Item target\x86_64-pc-windows-msvc\release\intervalcapture.exe ..\dist\client-win7-x64\intervalcapture.exe -Force
-Copy-Item target\x86_64-pc-windows-msvc\release\intervalcapture.exe ..\dist\client\intervalcapture.exe -Force
-```
+- 64비트: `rust\target\x86_64-pc-windows-msvc\release\intervalcapture.exe`
+- 32비트: `rust\target\i686-pc-windows-msvc\release\intervalcapture.exe`
 
-Windows 7 VM에서 OpenGL 2.0을 제공하지 못하는 경우를 대비해 Mesa llvmpipe 24.1.2의 `opengl32.dll`을 `intervalcapture.exe`와 같은 폴더에 포함한다.
+## OpenGL 폴백 DLL (Mesa llvmpipe) — 아키텍처별로 다름
 
-Mesa llvmpipe 24.1.2 파일이 없으면 먼저 내려받아 압축을 푼다.
+Windows 7 VM처럼 OpenGL 2.0을 제공하지 못하는 환경을 대비해 Mesa llvmpipe의 `opengl32.dll`을 `intervalcapture.exe`와 같은 폴더에 포함한다. **이 DLL은 exe 옆에 있으면 시스템 OpenGL보다 먼저 로드되므로, Windows 7 비호환 DLL을 넣으면 정상 GPU가 있는 Win7에서도 앱이 아예 실행되지 않는다.** 반드시 아키텍처와 Windows 7 호환성을 맞춘 DLL을 사용한다.
+
+중요 — Mesa 버전별 Windows 7 호환성:
+
+- **64비트: Mesa llvmpipe 24.1.2** (mmozeiko/build-mesa). Win7 안전.
+- **32비트: Mesa llvmpipe 24.3.4 x86** (mmozeiko의 x86 빌드 중 가장 오래된 버전). Win7 안전.
+- **26.x는 32/64비트 모두 사용 금지.** 26.x의 `opengl32.dll`은 Windows 8부터 추가된 `GetSystemTimePreciseAsFileTime`을 KERNEL32에서 정적 import한다. Windows 7에는 이 함수가 없어 로드 시점에 `프로시저 진입점 GetSystemTimePreciseAsFileTime을(를) ... KERNEL32.dll에서 찾을 수 없습니다` 오류로 실행이 실패한다. (일부 26.x는 `api-ms-*` apiset도 import한다.) 32비트 x86 빌드는 24.3.4까지만 Win7 안전이 확인되었다.
+
+64비트 DLL 내려받기(24.1.2, `.zip`):
 
 ```powershell
 New-Item -ItemType Directory -Force -Path target\mesa-candidates | Out-Null
 Invoke-WebRequest `
   -Uri https://github.com/mmozeiko/build-mesa/releases/download/24.1.2/mesa-llvmpipe-24.1.2.zip `
   -OutFile target\mesa-candidates\mesa-llvmpipe-24.1.2.zip
-
 New-Item -ItemType Directory -Force -Path target\mesa-candidates\24.1.2 | Out-Null
-Expand-Archive `
-  -LiteralPath target\mesa-candidates\mesa-llvmpipe-24.1.2.zip `
-  -DestinationPath target\mesa-candidates\24.1.2 `
-  -Force
+Expand-Archive -LiteralPath target\mesa-candidates\mesa-llvmpipe-24.1.2.zip `
+  -DestinationPath target\mesa-candidates\24.1.2 -Force
 ```
 
-그 다음 `opengl32.dll`을 클라이언트 배포 폴더에 복사한다.
+32비트 DLL 내려받기(24.3.4 x86, `.zip`):
 
 ```powershell
-Copy-Item target\mesa-candidates\24.1.2\opengl32.dll ..\dist\client-win7-x64\opengl32.dll -Force
-Copy-Item target\mesa-candidates\24.1.2\opengl32.dll ..\dist\client\opengl32.dll -Force
+Invoke-WebRequest `
+  -Uri https://github.com/mmozeiko/build-mesa/releases/download/24.3.4/mesa-llvmpipe-x86-24.3.4.zip `
+  -OutFile target\mesa-candidates\mesa-llvmpipe-x86-24.3.4.zip
+New-Item -ItemType Directory -Force -Path target\mesa-candidates\x86-24.3.4 | Out-Null
+Expand-Archive -LiteralPath target\mesa-candidates\mesa-llvmpipe-x86-24.3.4.zip `
+  -DestinationPath target\mesa-candidates\x86-24.3.4 -Force
 ```
-
-주의: 최신 Mesa llvmpipe 26.x의 `opengl32.dll`은 Windows 7에 없는 `api-ms-win-core-synch-l1-2-0.dll`을 import할 수 있으므로 Windows 7 배포물에 사용하지 않는다.
 
 클라이언트 배포물에는 `.bat` 실행 배치 파일을 만들거나 포함하지 않는다. 사용자는 `intervalcapture.exe`를 직접 실행하며, Windows 7 VM 대응은 같은 폴더에 둔 `opengl32.dll`로 처리한다.
 
-## 배포 ZIP 생성
+## 배포 폴더 구성
 
-배포 ZIP은 실행 중 생성된 스크린샷·로그가 섞이지 않도록 깨끗한 스테이징 폴더에서 만든다. `intervalcapture.exe`와 `opengl32.dll`만 포함한다.
+아키텍처별로 exe와 해당 아키텍처의 `opengl32.dll`만 넣는다. 실행 중 생성된 스크린샷·로그·settings.json이 섞이지 않도록 깨끗한 스테이징 폴더에서 만든다.
 
 ```powershell
-$StageRoot = "dist\release-staging"
-$ClientStage = Join-Path $StageRoot "client-win7-x64"
+# 64비트
+New-Item -ItemType Directory -Force -Path dist\pack\client-win7-x64 | Out-Null
+Copy-Item rust\target\x86_64-pc-windows-msvc\release\intervalcapture.exe dist\pack\client-win7-x64\intervalcapture.exe -Force
+Copy-Item rust\target\mesa-candidates\24.1.2\opengl32.dll dist\pack\client-win7-x64\opengl32.dll -Force
 
-Remove-Item -LiteralPath $ClientStage -Recurse -Force -ErrorAction SilentlyContinue
-New-Item -ItemType Directory -Force -Path $ClientStage | Out-Null
-Copy-Item rust\target\x86_64-pc-windows-msvc\release\intervalcapture.exe (Join-Path $ClientStage "intervalcapture.exe") -Force
-Copy-Item rust\target\mesa-candidates\24.1.2\opengl32.dll (Join-Path $ClientStage "opengl32.dll") -Force
-
-Compress-Archive -Path "$ClientStage\*" -DestinationPath dist\intervalcapture-client-win7-x64.zip -Force
+# 32비트
+New-Item -ItemType Directory -Force -Path dist\pack\client-win7-x86 | Out-Null
+Copy-Item rust\target\i686-pc-windows-msvc\release\intervalcapture.exe dist\pack\client-win7-x86\intervalcapture.exe -Force
+Copy-Item rust\target\mesa-candidates\x86-24.3.4\opengl32.dll dist\pack\client-win7-x86\opengl32.dll -Force
 ```
+
+## 압축 (반디집)
+
+반디집 콘솔(`bz.exe`)로 각 아키텍처 폴더를 압축한다. 암호 압축이 필요하면 `-p:<암호>`를 붙인다.
+
+```powershell
+$bz = "C:\Program Files\Bandizip\bz.exe"
+Set-Location dist\pack
+& $bz c -y -r -l:9 -p:12345678 ..\intervalcapture-win7-x64.zip client-win7-x64
+& $bz c -y -r -l:9 -p:12345678 ..\intervalcapture-win7-x86.zip client-win7-x86
+Set-Location ..\..
+```
+
+폴더명을 인자로 넘기면 압축 내부 경로가 `client-win7-x64\...`처럼 깔끔하게 유지된다(전체 경로 접두어가 붙지 않는다).
 
 ## 검증
 
-- `intervalcapture.exe`가 Windows GUI 서브시스템(PE Subsystem=2)으로 빌드되어 콘솔창을 띄우지 않는지 확인
-- PE OptionalHeader의 최소 OS 버전이 6.1(Windows 7) 이하인지 확인
-- `opengl32.dll`이 `api-ms-win-core-synch-l1-2-0.dll` 같은 `api-ms-*` DLL을 import하지 않는지 확인
-- 배포 ZIP 안에 `.bat` 파일, 스크린샷, 로그가 없는지 확인
-- 실행 후 `screenshots/`에 캡처 파일이 생성되고 `logs/년/월/일.log`에 로그가 기록되는지 확인
+각 아키텍처 exe와 동봉 DLL에 대해 확인한다.
+
+- exe가 Windows GUI 서브시스템(PE Subsystem=2)으로 빌드되어 콘솔창을 띄우지 않는지 확인
+- PE OptionalHeader의 최소 OS 버전이 6.0/6.1(Windows 7 이하)인지 확인
+- exe와 DLL의 아키텍처가 일치하는지 확인 (PE machine: x64=0x8664, x86=0x14c). 64비트 exe에는 64비트 DLL, 32비트 exe에는 32비트 DLL.
+- **DLL이 Windows 8+ 전용 함수를 import하지 않는지 확인한다.** `api-ms-*` apiset만이 아니라 KERNEL32의 개별 함수(특히 `GetSystemTimePreciseAsFileTime`, Windows 8+)도 반드시 확인한다. dumpbin으로 import 테이블을 직접 검사:
+
+```powershell
+$dumpbin = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\<버전>\bin\Hostx64\x64\dumpbin.exe"
+& $dumpbin /IMPORTS dist\pack\client-win7-x86\opengl32.dll | Select-String "GetSystemTimePreciseAsFileTime|api-ms"
+# 아무것도 출력되지 않아야 Win7 안전
+```
+
+- 배포 폴더/ZIP 안에 `.bat` 파일, 스크린샷, 로그, settings.json이 없는지 확인
+- 암호 압축본은 암호 없이 추출이 거부되고(`Password is needed`), 지정 암호로는 정상 추출되는지 확인
+- 실행 후 창이 뜨지 않고 트레이에만 상주하며, `screenshots/`에 캡처 파일이 생성되고 `logs/년/월/일.log`에 로그가 기록되는지 확인
 - 트레이 아이콘 우클릭 메뉴(표시/시작/정지/종료)가 창이 숨겨진 상태에서도 동작하는지 확인
 
-Windows 7 클라이언트 ZIP의 실제 Windows 7 실행 확인은 사용자가 수행한다. 빌드 작업 중에는 사용자가 명시적으로 요청하지 않는 한 VM을 시작하거나 조작하지 않는다.
+Windows 7 클라이언트의 실제 Windows 7 실행 확인은 사용자가 수행한다. 빌드 작업 중에는 사용자가 명시적으로 요청하지 않는 한 VM을 시작하거나 조작하지 않는다.
 
-- `intervalcapture.exe`만 복사하지 말고 배포 폴더 전체를 복사한다.
-- `opengl32.dll`이 `intervalcapture.exe`와 같은 폴더에 있어야 한다.
-- `egui_glow requires opengl 2.0+`는 VM 그래픽 드라이버가 OpenGL 2.0 이상을 제공하지 못한다는 뜻이다.
-- `api-ms-win-core-synch-l1-2-0.dll` 누락 오류는 Windows 7 비호환 Mesa DLL이 들어갔다는 뜻이다.
+## 참고 오류 메시지
+
+- `프로시저 진입점 GetSystemTimePreciseAsFileTime을(를) ... KERNEL32.dll에서 찾을 수 없습니다`: Windows 8+ 전용 함수를 import하는 Mesa DLL(26.x 등)이 들어간 경우. 24.1.2(x64)/24.3.4(x86)로 교체한다.
+- `api-ms-win-core-synch-l1-2-0.dll` 누락: Windows 7 비호환 Mesa DLL이 들어갔다는 뜻.
+- `egui_glow requires opengl 2.0+`: VM 그래픽 드라이버가 OpenGL 2.0 이상을 제공하지 못한다는 뜻. 같은 폴더에 올바른 `opengl32.dll`이 있는지 확인한다.
+- exe만 복사하지 말고 배포 폴더 전체(exe + `opengl32.dll`)를 복사한다. `opengl32.dll`은 `intervalcapture.exe`와 같은 폴더에 있어야 한다.

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,4 @@
-//! 화면 모니터링 - watch.py의 Rust 마이그레이션 (Windows 7 호환)
+//! 화면 캡쳐 - watch.py의 Rust 마이그레이션 (Windows 7 호환)
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod capture;
@@ -49,15 +49,15 @@ fn sync_tray_menu(capturing: bool) {
         if let Some((start, stop)) = &*cell.borrow() {
             start.set_enabled(!capturing);
             start.set_text(if capturing {
-                "⏸ 모니터링 시작 (실행 중)"
+                "⏸ 캡처 시작 (실행 중)"
             } else {
-                "▶ 모니터링 시작"
+                "▶ 캡처 시작"
             });
             stop.set_enabled(capturing);
             stop.set_text(if capturing {
-                "⏹ 모니터링 정지"
+                "⏹ 캡처 정지"
             } else {
-                "⏸ 모니터링 정지 (정지됨)"
+                "⏸ 캡처 정지 (정지됨)"
             });
         }
     });
@@ -99,7 +99,7 @@ fn stop_capture_shared(shared: &Arc<Shared>, rolling_cleanup: &Arc<RollingCleanu
 /// 창 제목으로 메인 창 HWND를 찾는다 (CreationContext에서 핸들을 못 얻은 경우 폴백)
 fn find_main_window() -> isize {
     use windows_sys::Win32::UI::WindowsAndMessaging::FindWindowW;
-    let title: Vec<u16> = "화면 모니터링\0".encode_utf16().collect();
+    let title: Vec<u16> = "화면 캡쳐\0".encode_utf16().collect();
     unsafe { FindWindowW(std::ptr::null(), title.as_ptr()) }
 }
 
@@ -206,16 +206,16 @@ fn build_tray() -> Result<TrayMenu, String> {
     let icon = tray_icon::Icon::from_rgba(rgba, w, h).map_err(|e| e.to_string())?;
 
     let menu = Menu::new();
-    let show_item = MenuItem::new("화면 모니터링 표시", true, None);
-    let start_item = MenuItem::new("▶ 모니터링 시작", true, None);
-    let stop_item = MenuItem::new("⏹ 모니터링 정지", true, None);
+    let show_item = MenuItem::new("화면 캡쳐 표시", true, None);
+    let start_item = MenuItem::new("▶ 캡처 시작", true, None);
+    let stop_item = MenuItem::new("⏹ 캡처 정지", true, None);
     let quit_item = MenuItem::new("종료", true, None);
     menu.append_items(&[&show_item, &start_item, &stop_item, &quit_item])
         .map_err(|e| e.to_string())?;
 
     let tray = TrayIconBuilder::new()
         .with_menu(Box::new(menu))
-        .with_tooltip("화면 모니터링")
+        .with_tooltip("화면 캡쳐")
         .with_icon(icon)
         .build()
         .map_err(|e| e.to_string())?;
@@ -245,7 +245,6 @@ struct App {
     cleanup_timer_start: Option<Instant>,
     quality: u8,
     saved_settings: settings::AppSettings,
-    started_at: Instant,
     hidden_after_start: bool,
     window_visible: bool,
 }
@@ -316,7 +315,7 @@ impl App {
             let ctx = cc.egui_ctx.clone();
             MenuEvent::set_event_handler(Some(move |event: MenuEvent| {
                 if event.id == ids.0 {
-                    // 화면 모니터링 표시
+                    // 화면 캡쳐 표시
                     show_window_raw(hwnd);
                     ctx.send_viewport_cmd(egui::ViewportCommand::Visible(true));
                     ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
@@ -351,9 +350,8 @@ impl App {
             cleanup_timer_start: None,
             quality: loaded.image_quality,
             saved_settings: loaded,
-            started_at: Instant::now(),
             hidden_after_start: false,
-            window_visible: true,
+            window_visible: false,
         };
 
         // GUI 로드 후 자동으로 캡처 시작
@@ -481,8 +479,9 @@ impl App {
 
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // 시작 0.5초 후 트레이로 숨김 (watch.py의 run()과 동일)
-        if !self.hidden_after_start && self.started_at.elapsed() > Duration::from_millis(500) {
+        // 시작 시 창은 만들자마자 숨긴다 (트레이 상주). 창이 이미 숨겨져 있어도
+        // 첫 프레임에서 OS가 잠깐 띄우는 것을 막기 위해 한 번 더 확실히 숨긴다.
+        if !self.hidden_after_start {
             self.hidden_after_start = true;
             self.window_visible = false;
             ctx.send_viewport_cmd(egui::ViewportCommand::Visible(false));
@@ -519,7 +518,7 @@ impl eframe::App for App {
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
                 ui.vertical_centered(|ui| {
-                    ui.heading("화면 모니터링");
+                    ui.heading("화면 캡쳐");
                 });
                 ui.add_space(8.0);
 
@@ -811,7 +810,8 @@ fn main() -> eframe::Result<()> {
     let mut viewport = egui::ViewportBuilder::default()
         .with_inner_size([450.0, 800.0])
         .with_resizable(false)
-        .with_title("화면 모니터링");
+        .with_visible(false) // 시작 시 창을 띄우지 않고 트레이에만 상주
+        .with_title("화면 캡쳐");
     if let Ok((rgba, w, h)) = load_app_icon() {
         viewport = viewport.with_icon(egui::IconData {
             rgba,
@@ -824,7 +824,7 @@ fn main() -> eframe::Result<()> {
         ..Default::default()
     };
     eframe::run_native(
-        "화면 모니터링",
+        "화면 캡쳐",
         options,
         Box::new(|cc| Box::new(App::new(cc))),
     )


### PR DESCRIPTION
## 변경 내용

### 앱 동작
- 이름 변경: "화면 모니터링" → **화면 캡쳐** (창 제목/트레이 툴팁/헤딩/메뉴)
- 시작 시 창을 띄우지 않고 곧바로 시스템 트레이에만 상주 (`with_visible(false)`). 트레이 "화면 캡쳐 표시"로 창을 연다.

### 32비트 빌드
- `i686-pc-windows-msvc` 타깃에 CRT 정적 링크 설정 추가 → 32비트 exe 빌드 가능
- 64비트/32비트 둘 다 Windows 7/10/11 대상

### 문서 (docs/release-build.md)
- 32/64비트 빌드·배포·반디집 압축 절차 정리
- **Mesa DLL Win7 호환성 교훈 반영**:
  - 64비트는 Mesa 24.1.2, 32비트는 Mesa 24.3.4 x86 사용
  - 26.x는 Windows 8+ 전용 `GetSystemTimePreciseAsFileTime`을 KERNEL32에서 정적 import → Win7에서 `프로시저 진입점 ... 찾을 수 없습니다` 로드 실패. 32/64비트 모두 금지.
  - 검증 단계에 dumpbin import 검사 추가 (`api-ms-*`뿐 아니라 개별 KERNEL32 함수까지 확인)

## 검증
- 64/32비트 exe 모두 GUI 서브시스템, 최소 OS 6.0, exe/DLL 아키텍처 일치 확인
- 32비트 exe가 Win7 안전 DLL(24.3.4)과 함께 정상 캡처 확인
- 두 Mesa DLL 모두 `GetSystemTimePreciseAsFileTime`/`api-ms-*` 미import 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)